### PR TITLE
Return promise so we don't forget promise resolution on errors

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -99,7 +99,7 @@ function streamImage(docker, image) {
     function missingImage() {
       debug('image is missing pull', image);
       // image is missing so pull it
-      docker.pull(image).then(function(rawPullStream) {
+      return docker.pull(image).then(function(rawPullStream) {
         rawPullStream.pipe(pullStream);
       });
     }


### PR DESCRIPTION
Not returning the promise causes us to violate promise resolution contract.

In docker-worker this is the cause of [bug 990257](https://bugzilla.mozilla.org/show_bug.cgi?id=990257), well it causes the task drop... Why the first request docker fails is an other question.
