### PR TITLE
Removing extra logs

### DIFF
--- a/docker_process.js
+++ b/docker_process.js
@@ -58,7 +58,7 @@ DockerProc.prototype = {
   */
   remove: function() {
     if (!this.container) {
-      return Promise.from(null);
+      return Promise.resolve(null);
     }
     return this.container.remove();
   },

--- a/package.json
+++ b/package.json
@@ -24,13 +24,12 @@
   },
   "homepage": "https://github.com/lightsofapollo/dockerode-process",
   "dependencies": {
-    "dockerode-promise":  "0.0.1",
-    "promise":            "~5.0.0",
+    "dockerode-promise":  "0.1.0",
+    "promise":            "~7.0.3",
     "debug":              "0.8.0"
   },
   "devDependencies": {
     "mocha":              "1.18.2",
-    "dockerode-options":  "~0.1.0",
-    "dockerode-promise":  "0.0.1"
+    "dockerode-options":  "~0.1.0"
   }
 }

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -35,9 +35,7 @@ suite('docker_utils', function() {
         docker.getImage(image).inspect().then(function image(result) {
           assert.ok(result);
           done();
-        }).catch(
-          done
-        );
+        }, done);
       });
     });
 

--- a/test/utils_test.js
+++ b/test/utils_test.js
@@ -35,7 +35,9 @@ suite('docker_utils', function() {
         docker.getImage(image).inspect().then(function image(result) {
           assert.ok(result);
           done();
-        }, done);
+        }).catch(
+          done
+        );
       });
     });
 

--- a/utils.js
+++ b/utils.js
@@ -21,14 +21,10 @@ PullStatusStream.prototype = {
     }
 
     if (json.id) {
-      var str = json.id + ' - ' + json.status;
-      if (json.progress) str += ' ' + json.progress;
-      str += '\r\n';
-      this.push(str);
-
       if (json.status == 'Downloading') {
         if (this.__layerStarts[json.id] === undefined) {
           this.__layerStarts[json.id] = new Date();
+          this.push('Started download of ' + json.id + '\r\n');
         }
       } else if (json.status == 'Download complete') {
         if (this.__layerStarts[json.id] !== undefined) {

--- a/utils.js
+++ b/utils.js
@@ -24,12 +24,13 @@ PullStatusStream.prototype = {
       if (json.status == 'Downloading') {
         if (this.__layerStarts[json.id] === undefined) {
           this.__layerStarts[json.id] = new Date();
-          this.push('Started download of ' + json.id + '\r\n');
+          this.push(json.id + ' - Started downloading\r\n');
         }
       } else if (json.status == 'Download complete') {
         if (this.__layerStarts[json.id] !== undefined) {
           var s = Math.abs(new Date() - this.__layerStarts[json.id]) / 1000;
-          this.push(json.id + ' - Downloaded in ' + s + ' seconds\r\n');
+          var ms = Math.abs(new Date() - this.__layerStarts[json.id]) % 1000;
+          this.push(json.id + ' - Downloaded in ' + s + '.' + 'ms' + ' seconds\r\n');
         }
       }
       return done();

--- a/utils.js
+++ b/utils.js
@@ -29,8 +29,7 @@ PullStatusStream.prototype = {
       } else if (json.status == 'Download complete') {
         if (this.__layerStarts[json.id] !== undefined) {
           var s = Math.abs(new Date() - this.__layerStarts[json.id]) / 1000;
-          var ms = Math.abs(new Date() - this.__layerStarts[json.id]) % 1000;
-          this.push(json.id + ' - Downloaded in ' + s + '.' + 'ms' + ' seconds\r\n');
+          this.push(json.id + ' - Downloaded in ' + s + ' seconds\r\n');
         }
       }
       return done();


### PR DESCRIPTION
Not sure if this is the best way to do this, or if it's even enough log removal. But it should help stem the ridiculous amount of unnecessary logs that come out of this thing. Note that this will clean out messages like `Pulling fs layer` and `Pulling metadata` (which might be useful, not sure) as well as the `Downloading =======` stuff (outright useless). I'm considering adding speed to make up for the lack of progress bar, but this should make the logs a lot less scrolling overall.